### PR TITLE
Disable ts-standard linting

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Lint Codebase
         id: super-linter
-        uses: super-linter/super-linter/slim@v6.8.0
+        uses: super-linter/super-linter/slim@v7
         env:
           DEFAULT_BRANCH: main
           FILTER_REGEX_EXCLUDE: dist/**/*
@@ -46,6 +46,7 @@ jobs:
           TYPESCRIPT_DEFAULT_STYLE: prettier
           VALIDATE_ALL_CODEBASE: true
           VALIDATE_JAVASCRIPT_STANDARD: false
+          VALIDATE_TYPESCRIPT_STANDARD: false
           VALIDATE_GO: false
           VALIDATE_GO_MODULES: false
           VALIDATE_JSCPD: false

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Lint Codebase
         id: super-linter
-        uses: super-linter/super-linter/slim@v6
+        uses: super-linter/super-linter/slim@v6.8.0
         env:
           DEFAULT_BRANCH: main
           FILTER_REGEX_EXCLUDE: dist/**/*


### PR DESCRIPTION
Example error:

    /github/workspace/__tests__/main.test.ts:0:0: Parsing error: '{' expected. (null)
    /github/workspace/__tests__/programs/random-nodejs/index.ts:0:0: File ignored because of a matching ignore pattern. Use "--no-ignore" to override. (null) (warning)
    /github/workspace/src/index.ts:0:0: Parsing error: '{' expected. (null)
    /github/workspace/src/main.ts:0:0: Parsing error: '{' expected. (null)
    /github/workspace/src/verifyRelease.ts:0:0: Parsing error: '{' expected. (null)

Downgrading the action had no effect on fixing the issue. I think this is due to the action only pinning the version of the main `ts-standard` library, but there's no lock file, so the sub-dependencies are floating, which is the source of this break.

We're still using eslint and prettier for typescript.