### PR TITLE
Use dotnet v8 in all tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/setup-python@v5
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '8.0.x'
       - uses: actions/setup-go@v5
         with:
           go-version: '1.21.x'

--- a/__tests__/programs/random-dotnet/scratch-yaml.csproj
+++ b/__tests__/programs/random-dotnet/scratch-yaml.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 


### PR DESCRIPTION
This should fix #89. The test program expects DotNet v6, but only v8 is installed currently.