### PR TITLE
Narrow the codeowners of this repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # Repository CODEOWNERS
 
-* @pulumi/providers
+* @pulumi/iac-ecosystem


### PR DESCRIPTION
`@pulumi/iac-ecosystem` is the appropriate code owner of this repo.