### PR TITLE
renovate: automatically rebuild dist

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ dist/
 node_modules/
 coverage/
 __tests__/programs/
+renovate.json5

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+renovate:
+	npm run bundle # Regenerates dist.

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 renovate:
-	npm run bundle # Regenerates dist.
+	npm ci && npm run bundle # Regenerates dist.

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,13 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: ['github>pulumi/renovate-config//default.json5'],
+  packageRules: [
+    {
+      matchPackagePatterns: ['*'],
+      postUpgradeTasks: {
+        commands: ['make renovate'], // Regenerate dist.
+        executionMode: 'branch' // Only run once.
+      }
+    }
+  ]
+}

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,11 +3,11 @@
   extends: ['github>pulumi/renovate-config//default.json5'],
   packageRules: [
     {
-      matchPackagePatterns: ['*'],
       postUpgradeTasks: {
-        commands: ['make renovate'], // Regenerate dist.
-        executionMode: 'branch' // Only run once.
-      }
+        commands: ['make renovate'],
+        executionMode: 'branch'
+      },
+      matchPackageNames: ['*']
     }
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "skipLibCheck": true,
     "newLine": "lf"
   },
-  "exclude": ["./dist", "./node_modules", "./__tests__", "./coverage"]
+  "exclude": ["./dist", "./node_modules", "./__tests__", "./coverage", "renovate.json5"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "skipLibCheck": true,
     "newLine": "lf"
   },
-  "exclude": ["./dist", "./node_modules", "./__tests__", "./coverage", "renovate.json5"]
+  "exclude": ["./dist", "./node_modules", "./__tests__", "./coverage"]
 }


### PR DESCRIPTION
Renovate is wrestling with pulumi-bot in https://github.com/pulumi/verify-provider-release/pull/164 because pulumi-bot is trying to re-build dist and Renovate wants to keep taking ownership of the branch. This eats up unnecessary GHA minutes.

This PR adds some config so Renovate can re-build dist automatically on its own.

`make renovate` is currently the only allowed post-run task, hence the addition of a Makefile.

There's an alternative where we could configure Renovate to give up ownership once pulumi-bot commits to a branch, but I'd like to move away from workflows that involve coordinating between the two systems.