### PR TITLE
Use ESC secrets

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -1,3 +1,9 @@
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 # In TypeScript actions, `dist/` is a special directory. When you reference
 # an action with the `uses:` property, `dist/index.js` is the code that will be
 # run. For this project, the `dist/index.js` file is transpiled from other
@@ -19,6 +25,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   check-dist:
@@ -26,6 +33,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Checkout
         id: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -48,9 +58,6 @@ jobs:
       - name: Build dist/ Directory
         id: build
         run: npm run bundle
-
-      # This will fail the workflow if the `dist/` directory is different than
-      # expected.
       - name: Compare Directories
         id: diff
         run: |
@@ -64,12 +71,7 @@ jobs:
             git diff --ignore-space-at-eol --text dist/
             exit 1
           fi
-
-      # If `dist/` was different than expected, upload the expected version as a
-      # workflow artifact.
-      - if:
-          ${{ failure() && steps.diff.outcome == 'failure' &&
-          !contains(github.actor, 'pulumi-bot') }}
+      - if: ${{ failure() && steps.diff.outcome == 'failure' && !contains(github.actor, 'pulumi-bot') }}
         name: Upload Artifact
         id: upload
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -77,9 +79,7 @@ jobs:
           name: dist
           path: dist/
 
-      - if:
-          ${{ failure() && steps.diff.outcome == 'failure' && github.event_name
-          == 'pull_request' && !contains(github.actor, 'pulumi-bot') }}
+      - if: ${{ failure() && steps.diff.outcome == 'failure' && github.event_name == 'pull_request' && !contains(github.actor, 'pulumi-bot') }}
         name: Push updated build
         run: |
           git config --global user.name pulumi-bot

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -71,7 +71,9 @@ jobs:
             git diff --ignore-space-at-eol --text dist/
             exit 1
           fi
-      - if: ${{ failure() && steps.diff.outcome == 'failure' && !contains(github.actor, 'pulumi-bot') }}
+      - if:
+          ${{ failure() && steps.diff.outcome == 'failure' &&
+          !contains(github.actor, 'pulumi-bot') }}
         name: Upload Artifact
         id: upload
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -79,7 +81,9 @@ jobs:
           name: dist
           path: dist/
 
-      - if: ${{ failure() && steps.diff.outcome == 'failure' && github.event_name == 'pull_request' && !contains(github.actor, 'pulumi-bot') }}
+      - if:
+          ${{ failure() && steps.diff.outcome == 'failure' && github.event_name
+          == 'pull_request' && !contains(github.actor, 'pulumi-bot') }}
         name: Push updated build
         run: |
           git config --global user.name pulumi-bot


### PR DESCRIPTION
These changes migrate this repo's GitHub Actions Workflows to use ESC secrets instead of GitHub Secrets.

The changes are largely mechanical:

- Common configuration for all ESC actions within a workflow is added to the workflow's environment variables
- Permissions are expanded as necessary for workflows that do not grant `id-token: write` permissions
	- `read-all` permissions are replaced with the union of all explicit read permissions and `id-token: write`
	- Default permissions are replaced with `write-all`, which is the equivalent of all explicit write permissions and
	  `id-token: write`
	- Explicit permissions are modified to grant `id-token: write`
- A step that fetches ESC secrets and populates environment variables is added to each step that reads secrets
- Direct references to secrets within the job are replaced with references to the step's outputs

All ESC actions are configured to fetch secrets from a shared ESC environment that contains secrets migrated from GitHub Actions. The ESC action performs its own OIDC exchange to obtain a Pulumi Access Token.
